### PR TITLE
Fix: Ensure existing share links are displayed in ShareModal

### DIFF
--- a/backend/src/api/docs.routes.js
+++ b/backend/src/api/docs.routes.js
@@ -278,8 +278,14 @@ router.post('/:shareToken', async (req, res) => {
 router.post('/get-or-create', async (req, res) => {
   const { repoId, filepath } = req.body;
   try {
-    let doc = await new Promise((resolve) => {
-        db.get('SELECT * FROM documents WHERE repo_id = ? AND filepath = ?', [repoId, filepath], (err, row) => resolve(row));
+    let doc = await new Promise((resolve, reject) => { // Added reject
+        db.get('SELECT * FROM documents WHERE repo_id = ? AND filepath = ?', [repoId, filepath], (err, row) => {
+            if (err) {
+                console.error("DB error in get-or-create/db.get during SELECT:", err); // Added more specific logging
+                return reject(err); // Reject the promise on error
+            }
+            resolve(row);
+        });
     });
     if (!doc) {
         const result = await new Promise((resolve, reject) => {


### PR DESCRIPTION
The ShareModal was failing to display existing share links because of an issue in the `/api/docs/get-or-create` endpoint. If the initial database lookup for an existing document failed, the endpoint would erroneously proceed to create a new document. The ID of this new document was then used by the ShareModal, leading to no existing links being found for it.

This commit addresses the issue by:
1. Modifying `backend/src/api/docs.routes.js`:
   - The promise for the `db.get` call in `/api/docs/get-or-create` now correctly rejects on database error. This ensures that failures in document lookup are propagated as errors and do not lead to the creation of a new, duplicate document entry.

2. Modifying `frontend/src/pages/DashboardPage.jsx`:
   - Enhanced error handling in the `openShareModal` function. It now checks the response from `/api/docs/get-or-create` and alerts you if there's an error or if an invalid document ID is returned. This prevents the ShareModal from opening with incorrect data.

These changes ensure that the ShareModal receives the correct document ID, allowing it to fetch and display any existing share links associated with that document.