### PR TITLE
feat: Enhance Quarto asset caching and serving

### DIFF
--- a/backend/src/api/assets.routes.js
+++ b/backend/src/api/assets.routes.js
@@ -4,7 +4,8 @@ const fs = require('fs');
 const db = require('../db/sqlite'); // Use the shared db connection
 
 const router = express.Router();
-const REPOS_DIR = path.join(__dirname, '../../repos');
+const REPOS_DIR = path.join(__dirname, '../../repos'); // Kept for potential other uses
+const CACHE_DIR = path.join(__dirname, '../../cache');
 
 // This endpoint is public but the paths are unguessable.
 // In a production app, you might add more security here.
@@ -27,14 +28,16 @@ router.get('/:repoId/:assetPath(*)', (req, res) => {
       return res.status(404).send('Repository not found');
     }
     
-    const repoFullName = row.full_name;
+    const repoFullName = row.full_name; // Still needed for validation that repoId is legit, but not for path
     
-    // Construct the asset path using the repository's full name
-    const fullAssetPath = path.join(REPOS_DIR, repoFullName, assetPath);
+    // Construct the asset path using CACHE_DIR, repoId, and the assetPath from the URL
+    // assetPath is expected to be: {commitHash}/{originalDocName_files}/{filename}
+    const fullAssetPath = path.join(CACHE_DIR, 'assets', repoId, assetPath);
 
     // Basic path traversal protection
     const safePath = path.resolve(fullAssetPath);
-    if (!safePath.startsWith(path.resolve(REPOS_DIR))) {
+    // Ensure the path is within the designated cache assets directory
+    if (!safePath.startsWith(path.resolve(path.join(CACHE_DIR, 'assets')))) {
       return res.status(403).send('Forbidden');
     }
 

--- a/backend/src/api/docs.routes.js
+++ b/backend/src/api/docs.routes.js
@@ -132,10 +132,10 @@ router.get('/view', async (req, res) => {
     }
 
     // Render the document to JATS
-    const { jatsXml } = await renderToJATS(fullFilepath, projectDir);
+    const { jatsXml, assetsCachePath } = await renderToJATS(fullFilepath, projectDir, effectiveRepoId, currentCommitHash);
     
     // Transform the JATS to ProseMirror JSON
-    const proseMirrorJson = await jatsToProseMirrorJSON(jatsXml, effectiveRepoId);
+    const proseMirrorJson = await jatsToProseMirrorJSON(jatsXml, effectiveRepoId, currentCommitHash, effectiveFilepath);
 
     // --- START CACHE WRITE LOGIC ---
     if (currentCommitHash && cacheFilename) { // Only attempt to write if cache setup was successful


### PR DESCRIPTION
I've improved the caching mechanism for Quarto rendered outputs. Previously, only the ProseMirror JSON was cached, and assets (like figures) were copied into your repository, which is not ideal.

This change introduces a new asset caching strategy:

1.  **Commit-Specific Asset Cache:** When a Quarto document is rendered, its assets (e.g., figures generated from code blocks) are now stored in a dedicated cache directory structured by repository ID and commit hash: `cache/assets/{repoId}/{commitHash}/{originalDocName}_files/`. This keeps your source repository clean.

2.  **Updated Asset URLs:** Image and figure URLs within the rendered ProseMirror JSON output are now rewritten to point to a new API endpoint structure: `/api/assets/{repoId}/{commitHash}/{originalDocName}_files/{assetFilename}`. This makes the asset URLs self-contained and version-specific.

3.  **Modified Asset Serving:** The `/api/assets/` endpoint has been updated to serve files from this new commit-specific asset cache, replacing the old behavior of serving from the live repository directory.

4.  **Integration Tests:** The existing cache integration tests have been significantly updated to:
    *   Include documents with images.
    *   Verify the creation of asset cache directories and the presence of asset files.
    *   Assert the correctness of the new asset URLs in the ProseMirror JSON output.
    *   Ensure proper cleanup of asset cache directories during testing.

These changes ensure that assets are cached efficiently alongside their corresponding document versions, are served correctly, and your repository itself is not cluttered with render artifacts.