### PR TITLE
fix: private repository support and parser compatibility

### DIFF
--- a/backend/src/core/quartoParser.js
+++ b/backend/src/core/quartoParser.js
@@ -1,13 +1,12 @@
 const matter = require('gray-matter');
-const { unified } = require('unified');
-const remarkParse = require('remark-parse').default;
+const { remark } = require('remark');
 const { renderChunk } = require('./quartoRunner');
 const { extractCommentsAppendix } = require('./commentUtils');
 
 async function qmdToProseMirror(qmdString) {
   const { comments, remainingQmdString } = extractCommentsAppendix(qmdString);
   const { data: yaml, content: markdown } = matter(remainingQmdString);
-  const tree = unified().use(remarkParse).parse(markdown);
+  const tree = remark().parse(markdown);
 
   const proseMirrorNodes = [];
 


### PR DESCRIPTION
## Summary

Fixes issues with adding and viewing private repositories.

## Changes

### URL Parsing Fix
- Handle trailing slashes in repo URLs (e.g., `https://github.com/user/repo/`)
- Previously caused 'Repository not found' errors

### Private Repo Authentication
- Add `onAuth` to `git.pull()` - was missing authentication for private repos
- Clone worked but pull failed silently, causing the request to hang

### Parser ESM/CJS Fix
- Replace `unified().use(remarkParse)` with `remark().parse()`
- unified v11+ has ESM/CJS compatibility issues with `require()`
- Fixes 'Cannot parse without Parser' errors

## Testing

1. Add a private repository URL (with or without trailing slash)
2. Click on the repo to list .qmd files
3. Open a .qmd file - should render without errors